### PR TITLE
Adding support for IE & Firefox

### DIFF
--- a/src/ng2-simple-page-scroll.directive.ts
+++ b/src/ng2-simple-page-scroll.directive.ts
@@ -50,6 +50,11 @@ export class SimplePageScroll {
               anchorTarget.scrollTop +
               anchorTarget.clientTop +
               SimplePageScrollConfig.defaultScrollOffset;
+            this.document.documentElement.scrollTop =
+              anchorTarget.offsetTop -
+              anchorTarget.scrollTop +
+              anchorTarget.clientTop +
+              SimplePageScrollConfig.defaultScrollOffset;
         }
     }
 }


### PR DESCRIPTION
The scrolling relies on usage of body.scrollTop, which is non-standard and generally only supported by Blink-based browsers. I added document.documentElement.scrollTop support for IE & Firefox.
